### PR TITLE
fix: address Copilot PR review feedback (v0.7.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y shfmt
 
       - name: Run ShellCheck
-        run: shellcheck hardnormly.sh lib/*.sh .githooks/pre-commit scripts/setup-hooks.sh scripts/generate_exclusion_bed.sh tests/setup_bats.sh
+        run: shellcheck hardnormly.sh lib/*.sh .githooks/pre-commit scripts/setup-hooks.sh scripts/generate_exclusion_bed.sh scripts/generate_config.sh scripts/run_snakemake.sh tests/setup_bats.sh
 
       - name: Check shfmt formatting
-        run: shfmt -d -i 0 -bn -ci hardnormly.sh lib/*.sh .githooks/pre-commit scripts/setup-hooks.sh scripts/generate_exclusion_bed.sh tests/setup_bats.sh
+        run: shfmt -d -i 0 -bn -ci hardnormly.sh lib/*.sh .githooks/pre-commit scripts/setup-hooks.sh scripts/generate_exclusion_bed.sh scripts/generate_config.sh scripts/run_snakemake.sh tests/setup_bats.sh
 
   test:
     name: Test

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 
 SHFMT_FLAGS := -i 0 -bn -ci
 
-# Shell scripts to check (excludes Snakemake launcher which is out of scope)
-SH_FILES := hardnormly.sh $(wildcard lib/*.sh) .githooks/pre-commit scripts/setup-hooks.sh scripts/generate_exclusion_bed.sh tests/setup_bats.sh
+# Shell scripts to check
+SH_FILES := hardnormly.sh $(wildcard lib/*.sh) .githooks/pre-commit scripts/setup-hooks.sh scripts/generate_exclusion_bed.sh scripts/generate_config.sh scripts/run_snakemake.sh tests/setup_bats.sh
 
 .PHONY: lint format check-format check-shellcheck setup-hooks test test-debug help
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-hardnormly is a modular bash application. The main script (`hardnormly.sh`, ~445 lines) orchestrates the pipeline and subcommands by sourcing eight focused library modules.
+hardnormly is a modular bash application. The main script (`hardnormly.sh`) orchestrates the pipeline and subcommands by sourcing eight focused library modules.
 
 ## Module Structure
 
@@ -88,7 +88,7 @@ Formatting uses tabs, binary ops at line start, case body indent (`shfmt -i 0 -b
 ### Testing
 
 ```bash
-make test           # Run all 120 BATS tests
+make test           # Run full BATS test suite
 make test-debug     # Verbose output, keep temp dirs
 ```
 

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -65,7 +65,7 @@ When BED files are provided (`--include-bed` / `--exclude-bed`), two region filt
 | Filter Name | Condition | Meaning |
 |-------------|-----------|---------|
 | `NOT_IN_INCLUDE_REGION` | `INFO/INCLUDE_REGION!=1` | Variant is outside all inclusion regions |
-| `IN_EXCLUDE_REGION` | `INFO/EXCLUDE_REGION=1` | Variant is inside an exclusion region |
+| `IN_EXCLUDE_REGION` | `INFO/EXCLUDE_REGION==1` | Variant is inside an exclusion region |
 
 These are applied **before** any user-defined filters.
 

--- a/hardnormly.sh
+++ b/hardnormly.sh
@@ -405,7 +405,7 @@ if [[ -f "$tmp_dir/merged_include_regions.bed.gz" ]]; then
 	filter_stages+=("NOT_IN_INCLUDE_REGION|e|INFO/INCLUDE_REGION!=1")
 fi
 if [[ -f "$tmp_dir/merged_exclude_regions.bed.gz" ]]; then
-	filter_stages+=("IN_EXCLUDE_REGION|e|INFO/EXCLUDE_REGION=1")
+	filter_stages+=("IN_EXCLUDE_REGION|e|INFO/EXCLUDE_REGION==1")
 fi
 
 # Parse inline and file-based filters into filter_stages (delegates to lib/cli.sh)

--- a/hardnormly.sh
+++ b/hardnormly.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script version
-version="0.7.0"
+version="0.7.1"
 
 set -Eeuo pipefail
 

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -43,9 +43,16 @@ debug_msg() {
 	log_msg "[DEBUG] $1"
 }
 
-# error_msg — write an ERROR-prefixed message to stderr
+# error_msg — write an ERROR-prefixed message to stderr (and log file if set)
 error_msg() {
-	log_msg "ERROR: $1" >&2
+	local timestamp
+	timestamp=$(date +"%Y-%m-%d %H:%M:%S")
+	# Always write to stderr to honor the function contract
+	echo "[$timestamp] ERROR: $1" >&2
+	# Additionally append to log file when configured
+	if [[ -n "$_LOG_FILE" ]]; then
+		echo "[$timestamp] ERROR: $1" >>"$_LOG_FILE"
+	fi
 }
 
 # run_cmd — execute a command and capture stderr; report details on failure

--- a/scripts/run_snakemake.sh
+++ b/scripts/run_snakemake.sh
@@ -8,7 +8,10 @@
 #SBATCH --output=slurm_logs/%x-%j.log
 
 set -euo pipefail
-shopt -s inherit_errexit
+# inherit_errexit requires Bash >= 4.4; guard for portability on older HPC systems
+if [[ "${BASH_VERSINFO[0]}" -gt 4 || ("${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4) ]]; then
+	shopt -s inherit_errexit
+fi
 
 # ── Cluster auto-detection ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **lib/logging.sh**: fix `error_msg` to always write to stderr regardless of `_LOG_FILE` state — honors the function contract and ensures errors surface in both file-backed and console logging modes
- **scripts/run_snakemake.sh**: guard `inherit_errexit` with a Bash >= 4.4 version check for portability on older HPC cluster nodes
- **Makefile + ci.yml**: add `scripts/generate_config.sh` and `scripts/run_snakemake.sh` to lint/format coverage so all shell scripts are checked on every PR
- **docs/architecture.md**: remove stale hardcoded line count and test count (avoids doc rot)
- **docs/filters.md + hardnormly.sh**: standardize `EXCLUDE_REGION` filter expression from `=` to `==` for consistency with all other bcftools expressions

All 130 tests pass. Bumps patch version to 0.7.1.

## Test plan

- [x] `make lint` passes (shellcheck + shfmt, now including both new scripts)
- [x] `make test` — 130/130 BATS tests pass
- [x] CI Lint and Test jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
